### PR TITLE
fix #4 Pinning the version of Deepstream App TAO to 6.0.1

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -77,8 +77,9 @@ echo
 echo Building Python wrapper library for gazeinfer...
 cd $GAZE_DIR/ds/lib/gazeinfer
 if [ ! -d deepstream_tao_apps ]; then
-	git clone https://github.com/NVIDIA-AI-IOT/deepstream_tao_apps
+	git clone https://github.com/NVIDIA-AI-IOT/deepstream_tao_apps -b release/tao3.0_ds6.0.1
 fi
+
 env CUDA_VER=$CUDA_VER make
 cp dscprobes.so $GAZE_DIR/ds/lib
 echo done.


### PR DESCRIPTION
This patch git clones a specific branch.

If you are working on Deepstream 6.1, you can ignore this patch.
However, it is a good idea to add the setting to clone this particular branch for future use.