### PR TITLE
Feature docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ model/gaze/tao-converter*
 !model/*
 model/age/*.engine
 model/gender/*.engine
+sources/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-base
+FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-samples
 
 WORKDIR /root/Gaze-Analysis-System
-COPY sources/   /opt/nvidia/deepstream/deepstream-6.0/sources/
 COPY . .
 
 RUN env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-base
+
+WORKDIR /root/Gaze-Analysis-System
+COPY sources/   /opt/nvidia/deepstream/deepstream-6.0/sources/
+COPY . .
+
+RUN env
+
+RUN echo -n 'deb https://repo.download.nvidia.com/jetson/common r32.7 main\n\
+deb https://repo.download.nvidia.com/jetson/t194 r32.7 main\n'\
+>> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+
+RUN apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-public.asc && apt update && apt install -y libopencv-python python3-numpy
+
+RUN bash ./setup.sh
+RUN pip3 install Cython --install-option="--no-cython-compile"
+RUN echo -n 'export LD_LIBRARY_PATH=/opt/nvidia/deepstream/deepstream/lib/cvcore_libs:$LD_LIBRARY_PATH\n' >> /root/.bashrc

--- a/docker-build-run.txt
+++ b/docker-build-run.txt
@@ -1,7 +1,7 @@
 # example to run image
 
 # build docker image
-docker build -t gaze-analysis .
+bash ./docker-build.sh
 
 # exec docker
 docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix --device /dev/video0:/dev/video0:mrw gaze-analysis

--- a/docker-build-run.txt
+++ b/docker-build-run.txt
@@ -3,8 +3,11 @@
 # build docker image
 bash ./docker-build.sh
 
-# exec docker
+# exec command 'xhost +' on terminal before run docker
+xhost +
+
+# run docker
 docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix --device /dev/video0:/dev/video0:mrw gaze-analysis
 
 # exec run.py in docker container
-python3 run.py /dev/video0 --media v4l2 --codec mjpg --width 1280 --height 720 --cam-fps
+python3 run.py /dev/video0 --media v4l2 --codec mjpg --width 1280 --height 720

--- a/docker-build-run.txt
+++ b/docker-build-run.txt
@@ -1,0 +1,10 @@
+# example to run image
+
+# build docker image
+docker build -t gaze-analysis .
+
+# exec docker
+docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix --device /dev/video0:/dev/video0:mrw gaze-analysis
+
+# exec run.py in docker container
+python3 run.py /dev/video0 --media v4l2 --codec mjpg --width 1280 --height 720 --cam-fps

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mkdir sources ; pushd sources
+cp -rf /opt/nvidia/deepstream/deepstream-6.0/sources/includes/    .
+cp -rf /opt/nvidia/deepstream/deepstream-6.0/sources/gst-plugins/ .
+popd
+
+unset DOCKER_BUILDKIT
+docker build -t gaze-analysis .

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-mkdir sources ; pushd sources
-cp -rf /opt/nvidia/deepstream/deepstream-6.0/sources/includes/    .
-cp -rf /opt/nvidia/deepstream/deepstream-6.0/sources/gst-plugins/ .
-popd
+# for build gaze-analysis
 
 unset DOCKER_BUILDKIT
 docker build -t gaze-analysis .

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,13 @@ function finally {
 	cd $GAZE_DIR
 }
 
+# CHECK EXIST sudo COMMAND
+sudo ()
+{
+    [[ $EUID = 0 ]] || set -- command sudo "$@"
+    "$@"
+}
+
 # CHECK DEEPSTREAM INSTALATION
 echo Checking DeepStream installation...
 if [ ! -f $DEEPSTREAM_DIR/version ]; then 
@@ -35,7 +42,7 @@ sudo apt install -y gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-plugins-ba
 	gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav libgstreamer1.0-dev\
 	libgstreamer-plugins-base1.0-dev   libgstreamer-plugins-good1.0-dev   libgstreamer-plugins-bad1.0-dev\
 	python3-dev python-gi-dev python3-pip git libgirepository1.0-dev libcairo2-dev apt-transport-https\
-       	ca-certificates cmake libjpeg-dev
+	ca-certificates cmake libjpeg-dev unzip
 pip3 install Pillow azure-iot-device
 echo done.
 echo


### PR DESCRIPTION
[feature-add-dockerfile](https://github.com/Ryoyo-NV/Gaze-Analysis-System/tree/feature-add-dockerfile) branch contained `includes` and `gst-plugins` of Deepstream-6.0 source code and was double managed.

Therefore, I added a build script called `docker-build.sh` that creates Docker images. This shell script pre-copies the required source code of Deepstream-6.0 before the Docker build.

Also, the setup.sh could not be executed because the sudo command was not present in the Docker image, so it was run without sudo when running with root privileges.

And add a sample text `docker-build-run.txt` to exec command `build` and `run`